### PR TITLE
Add tests for region mask

### DIFF
--- a/main.py
+++ b/main.py
@@ -1111,7 +1111,6 @@ def main(args):
                     U_std.flat[i] = np.linalg.norm(std_samp)
                 U_std = U_std.reshape(cfg['grid_size_test'],cfg['grid_size_test'],cfg['grid_size_test'])
                 plot_field_gorkov_3d(U_mean, U_std, X, Y, Z, z_idx=cfg['grid_size_test']//2, savedir=cfg.get('logdir','./logs'))
-main(args)
 # --------- CLI 실행 ---------
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Meta-PINO-AFC 논문 전체 실험 파이프라인")

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,29 @@
+import torch
+import importlib
+
+# Import the get_region_mask function without triggering main execution
+module = importlib.import_module('main')
+get_region_mask = module.get_region_mask
+
+
+def test_get_region_mask_basic():
+    coords = torch.tensor([
+        [0.0, 0.0, 1.0],
+        [0.4, 0.0, 1.0],
+        [0.95, 0.0, 1.0],
+        [-0.95, 0.0, 1.0],
+        [1.05, 0.0, 1.0],
+        [0.0, 0.0, -0.05],
+        [0.0, 0.0, 2.05],
+        [1.5, 0.0, 1.0],
+    ], dtype=torch.float32)
+    mask = get_region_mask(
+        coords,
+        target_region_center=(0.0, 0.0, 1.0),
+        target_radius=1.0,
+        boundary_range=0.1,
+        xy_range=1.0,
+        z_range=(0.0, 2.0),
+    )
+    expected = torch.tensor([1, 1, 1, 1, 2, 2, 2, 0])
+    assert torch.equal(mask.cpu(), expected)


### PR DESCRIPTION
## Summary
- fix accidental call to `main()` during imports
- add `tests/` directory with a regression test for `get_region_mask`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684bdac79ea883318b84f20e369d42c2